### PR TITLE
Revert most of the 79-char linewrapping in objectstore 

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -94,13 +94,11 @@ class ObjectStore(object):
         """Close any connections for this ObjectStore."""
         self.running = False
 
-    def exists(self, obj, base_dir=None, dir_only=False, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None):
+    def exists(self, obj, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None):
         """Return True if the object identified by `obj` exists, False otherwise."""
         raise NotImplementedError()
 
-    def file_ready(self, obj, base_dir=None, dir_only=False, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def file_ready(self, obj, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Check if a file corresponding to a dataset is ready to be used.
 
@@ -108,8 +106,7 @@ class ObjectStore(object):
         """
         return True
 
-    def create(self, obj, base_dir=None, dir_only=False, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def create(self, obj, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Mark the object (`obj`) as existing in the store, but with no content.
 
@@ -118,8 +115,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def empty(self, obj, base_dir=None, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def empty(self, obj, base_dir=None, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Test if the object identified by `obj` has content.
 
@@ -127,8 +123,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def size(self, obj, extra_dir=None, extra_dir_at_root=False, alt_name=None,
-            obj_dir=False):
+    def size(self, obj, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Return size of the object identified by `obj`.
 
@@ -136,8 +131,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def delete(self, obj, entire_dir=False, base_dir=None, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def delete(self, obj, entire_dir=False, base_dir=None, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Delete the object identified by `obj`.
 
@@ -149,8 +143,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def get_data(self, obj, start=0, count=-1, base_dir=None, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def get_data(self, obj, start=0, count=-1, base_dir=None, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Fetch `count` bytes of data offset by `start` bytes using `obj.id`.
 
@@ -164,8 +157,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def get_filename(self, obj, base_dir=None, dir_only=False, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def get_filename(self, obj, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Get the expected filename with absolute path for object with id `obj.id`.
 
@@ -173,9 +165,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def update_from_file(self, obj, base_dir=None, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False,
-            file_name=None, create=False):
+    def update_from_file(self, obj, base_dir=None, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False, file_name=None, create=False):
         """
         Inform the store that the file associated with `obj.id` has been updated.
 
@@ -193,8 +183,7 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
-    def get_object_url(self, obj, extra_dir=None, extra_dir_at_root=False,
-            alt_name=None, obj_dir=False):
+    def get_object_url(self, obj, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Return the URL for direct acces if supported, otherwise return None.
 
@@ -243,8 +232,7 @@ class DiskObjectStore(ObjectStore):
         file_path -- Override for the config.file_path value.
         extra_dirs -- Dictionary: keys are string, values are directory paths.
         """
-        super(DiskObjectStore, self).__init__(config, config_xml=None,
-                file_path=file_path, extra_dirs=extra_dirs)
+        super(DiskObjectStore, self).__init__(config, config_xml=None, file_path=file_path, extra_dirs=extra_dirs)
         self.file_path = file_path or config.file_path
         # The new config_xml overrides universe settings.
         if config_xml is not None:
@@ -256,28 +244,24 @@ class DiskObjectStore(ObjectStore):
         if extra_dirs is not None:
             self.extra_dirs.update( extra_dirs )
 
-    def _get_filename(self, obj, base_dir=None, dir_only=False, extra_dir=None,
-            extra_dir_at_root=False, alt_name=None, obj_dir=False):
+    def _get_filename(self, obj, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Return the absolute path for the file corresponding to the `obj.id`.
 
         This is regardless of whether or not the file exists.
         """
-        path = self._construct_path(obj, base_dir=base_dir, dir_only=dir_only,
-                extra_dir=extra_dir, extra_dir_at_root=extra_dir_at_root,
-                alt_name=alt_name, obj_dir=False, old_style=True)
+        path = self._construct_path(obj, base_dir=base_dir, dir_only=dir_only, extra_dir=extra_dir,
+                                    extra_dir_at_root=extra_dir_at_root, alt_name=alt_name,
+                                    obj_dir=False, old_style=True)
         # For backward compatibility: check the old style root path first;
         # otherwise construct hashed path.
         if not os.path.exists(path):
-            return self._construct_path(obj, base_dir=base_dir,
-                    dir_only=dir_only, extra_dir=extra_dir,
-                    extra_dir_at_root=extra_dir_at_root, alt_name=alt_name)
+            return self._construct_path(obj, base_dir=base_dir, dir_only=dir_only, extra_dir=extra_dir,
+                                        extra_dir_at_root=extra_dir_at_root, alt_name=alt_name)
 
     # TODO: rename to _disk_path or something like that to avoid conflicts with
     # children that'll use the local_extra_dirs decorator, e.g. S3
-    def _construct_path(self, obj, old_style=False, base_dir=None,
-            dir_only=False, extra_dir=None, extra_dir_at_root=False,
-            alt_name=None, obj_dir=False, **kwargs):
+    def _construct_path(self, obj, old_style=False, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False, **kwargs):
         """
         Construct the absolute path for accessing the object identified by `obj.id`.
 
@@ -327,8 +311,7 @@ class DiskObjectStore(ObjectStore):
                     rel_path = os.path.join(rel_path, extra_dir)
             path = os.path.join(base, rel_path)
         if not dir_only:
-            path = os.path.join(path, alt_name if alt_name
-                else "dataset_%s.dat" % obj.id)
+            path = os.path.join(path, alt_name if alt_name else "dataset_%s.dat" % obj.id)
         return os.path.abspath(path)
 
     def exists(self, obj, **kwargs):
@@ -385,8 +368,7 @@ class DiskObjectStore(ObjectStore):
                 os.remove(path)
                 return True
         except OSError, ex:
-            log.critical('%s delete error %s' % (self._get_filename(
-                obj, **kwargs), ex))
+            log.critical('%s delete error %s' % (self._get_filename(obj, **kwargs), ex))
         return False
 
     def get_data(self, obj, start=0, count=-1, **kwargs):
@@ -423,14 +405,11 @@ class DiskObjectStore(ObjectStore):
         if file_name and self.exists(obj, **kwargs):
             try:
                 if preserve_symlinks and os.path.islink( file_name ):
-                    force_symlink( os.readlink( file_name ),
-                            self.get_filename( obj, **kwargs ) )
+                    force_symlink( os.readlink( file_name ), self.get_filename( obj, **kwargs ) )
                 else:
-                    shutil.copy( file_name,
-                            self.get_filename( obj, **kwargs ) )
+                    shutil.copy( file_name, self.get_filename( obj, **kwargs ) )
             except IOError, ex:
-                log.critical('Error copying %s to %s: %s'
-                        % (file_name, self._get_filename(obj, **kwargs), ex))
+                log.critical('Error copying %s to %s: %s' % (file_name, self._get_filename(obj, **kwargs), ex))
                 raise ex
 
     def get_object_url(self, obj, **kwargs):
@@ -492,21 +471,18 @@ class NestedObjectStore(ObjectStore):
 
     def get_data(self, obj, **kwargs):
         """For the first backend that has this `obj`, get data from it."""
-        return self._call_method(
-            'get_data', obj, ObjectNotFound, True, **kwargs)
+        return self._call_method('get_data', obj, ObjectNotFound, True, **kwargs)
 
     def get_filename(self, obj, **kwargs):
         """For the first backend that has this `obj`, get its filename."""
-        return self._call_method(
-            'get_filename', obj, ObjectNotFound, True, **kwargs)
+        return self._call_method('get_filename', obj, ObjectNotFound, True, **kwargs)
 
     def update_from_file(self, obj, **kwargs):
         """For the first backend that has this `obj`, update it from the given file."""
         if kwargs.get('create', False):
             self.create(obj, **kwargs)
             kwargs['create'] = False
-        return self._call_method(
-            'update_from_file', obj, ObjectNotFound, True, **kwargs)
+        return self._call_method('update_from_file', obj, ObjectNotFound, True, **kwargs)
 
     def get_object_url(self, obj, **kwargs):
         """For the first backend that has this `obj`, get its URL."""
@@ -519,9 +495,8 @@ class NestedObjectStore(ObjectStore):
             if store.exists(obj, **kwargs):
                 return store.__getattribute__(method)(obj, **kwargs)
         if default_is_exception:
-            raise default(
-                'objectstore, _call_method failed: %s on %s, kwargs: %s'
-                % ( method, str( obj ), str( kwargs ) ) )
+            raise default('objectstore, _call_method failed: %s on %s, kwargs: %s'
+                          % ( method, str( obj ), str( kwargs ) ) )
         else:
             return default
 
@@ -551,8 +526,7 @@ class DistributedObjectStore(NestedObjectStore):
         super(DistributedObjectStore, self).__init__(config,
                 config_xml=config_xml)
         if config_xml is None:
-            self.distributed_config = \
-                config.distributed_object_store_config_file
+            self.distributed_config = config.distributed_object_store_config_file
             assert self.distributed_config is not None, \
                 "distributed object store ('object_store = distributed') " \
                 "requires a config file, please set one in " \
@@ -565,11 +539,9 @@ class DistributedObjectStore(NestedObjectStore):
         random.seed()
         self.__parse_distributed_config(config, config_xml)
         self.sleeper = None
-        if fsmon and ( self.global_max_percent_full or
-                filter( lambda x: x != 0.0, self.max_percent_full.values() ) ):
+        if fsmon and ( self.global_max_percent_full or filter( lambda x: x != 0.0, self.max_percent_full.values() ) ):
             self.sleeper = Sleeper()
-            self.filesystem_monitor_thread = threading.Thread(
-                target=self.__filesystem_monitor)
+            self.filesystem_monitor_thread = threading.Thread(target=self.__filesystem_monitor)
             self.filesystem_monitor_thread.setDaemon( True )
             self.filesystem_monitor_thread.start()
             log.info("Filesystem space monitor started")
@@ -577,12 +549,10 @@ class DistributedObjectStore(NestedObjectStore):
     def __parse_distributed_config(self, config, config_xml=None):
         if config_xml is None:
             root = ElementTree.parse(self.distributed_config).getroot()
-            log.debug('Loading backends for distributed object store from %s'
-                    % self.distributed_config)
+            log.debug('Loading backends for distributed object store from %s', self.distributed_config)
         else:
             root = config_xml.find('backends')
-            log.debug('Loading backends for distributed object store from %s'
-                    % config_xml.get('id'))
+            log.debug('Loading backends for distributed object store from %s', config_xml.get('id'))
         self.global_max_percent_full = float(root.get('maxpctfull', 0))
         for elem in [ e for e in root if e.tag == 'backend' ]:
             id = elem.get('id')
@@ -597,11 +567,9 @@ class DistributedObjectStore(NestedObjectStore):
                     elif sub.tag == 'extra_dir':
                         type = sub.get('type')
                         extra_dirs[type] = sub.get('path')
-                self.backends[id] = DiskObjectStore(config, file_path=path,
-                        extra_dirs=extra_dirs)
+                self.backends[id] = DiskObjectStore(config, file_path=path, extra_dirs=extra_dirs)
                 self.max_percent_full[id] = maxpctfull
-                log.debug("Loaded disk backend '%s' with weight %s and "
-                        "file_path: %s" % (id, weight, path))
+                log.debug("Loaded disk backend '%s' with weight %s and file_path: %s" % (id, weight, path))
                 if extra_dirs:
                     log.debug("    Extra directories:")
                     for type, dir in extra_dirs.items():
@@ -623,68 +591,54 @@ class DistributedObjectStore(NestedObjectStore):
         while self.running:
             new_weighted_backend_ids = self.original_weighted_backend_ids
             for id, backend in self.backends.items():
-                maxpct = self.max_percent_full[id] or \
-                    self.global_max_percent_full
+                maxpct = self.max_percent_full[id] or self.global_max_percent_full
                 pct = backend.get_store_usage_percent()
                 if pct > maxpct:
-                    new_weighted_backend_ids = filter(
-                        lambda x: x != id, new_weighted_backend_ids)
+                    new_weighted_backend_ids = filter(lambda x: x != id, new_weighted_backend_ids)
             self.weighted_backend_ids = new_weighted_backend_ids
             self.sleeper.sleep(120)  # Test free space every 2 minutes
 
     def create(self, obj, **kwargs):
         """The only method in which obj.object_store_id may be None."""
         if obj.object_store_id is None or not self.exists(obj, **kwargs):
-            if obj.object_store_id is None or \
-                    obj.object_store_id not in self.weighted_backend_ids:
+            if obj.object_store_id is None or obj.object_store_id not in self.weighted_backend_ids:
                 try:
-                    obj.object_store_id = random.choice(
-                        self.weighted_backend_ids)
+                    obj.object_store_id = random.choice(self.weighted_backend_ids)
                 except IndexError:
-                    raise ObjectInvalid(
-                        'objectstore.create, could not generate '
-                        'obj.object_store_id: %s, kwargs: %s'
-                        % ( str( obj ), str( kwargs ) ) )
+                    raise ObjectInvalid('objectstore.create, could not generate '
+                                        'obj.object_store_id: %s, kwargs: %s'
+                                        % ( str( obj ), str( kwargs ) ) )
                 _create_object_in_session( obj )
                 log.debug("Selected backend '%s' for creation of %s %s"
-                        % (obj.object_store_id,
-                            obj.__class__.__name__, obj.id))
+                          % (obj.object_store_id, obj.__class__.__name__, obj.id))
             else:
                 log.debug("Using preferred backend '%s' for creation of %s %s"
-                        % (obj.object_store_id,
-                            obj.__class__.__name__, obj.id))
+                          % (obj.object_store_id, obj.__class__.__name__, obj.id))
             self.backends[obj.object_store_id].create(obj, **kwargs)
 
-    def _call_method(self, method, obj, default, default_is_exception,
-            **kwargs):
+    def _call_method(self, method, obj, default, default_is_exception, **kwargs):
         object_store_id = self.__get_store_id_for(obj, **kwargs)
         if object_store_id is not None:
-            return self.backends[object_store_id].__getattribute__(method)(obj,
-                    **kwargs)
+            return self.backends[object_store_id].__getattribute__(method)(obj, **kwargs)
         if default_is_exception:
-            raise default(
-                'objectstore, _call_method failed: %s on %s, kwargs: %s'
-                % ( method, str( obj ), str( kwargs ) ) )
+            raise default('objectstore, _call_method failed: %s on %s, kwargs: %s'
+                          % ( method, str( obj ), str( kwargs ) ) )
         else:
             return default
 
     def __get_store_id_for(self, obj, **kwargs):
-        if obj.object_store_id is not None and \
-                obj.object_store_id in self.backends:
+        if obj.object_store_id is not None and obj.object_store_id in self.backends:
             return obj.object_store_id
         else:
             # if this instance has been switched from a non-distributed to a
             # distributed object store, or if the object's store id is invalid,
             # try to locate the object
-            log.warning(
-                'The backend object store ID (%s) for %s object with ID '
-                '%s is invalid'
-                % (obj.object_store_id, obj.__class__.__name__, obj.id))
+            log.warning('The backend object store ID (%s) for %s object with ID %s is invalid'
+                        % (obj.object_store_id, obj.__class__.__name__, obj.id))
             for id, store in self.backends.items():
                 if store.exists(obj, **kwargs):
-                    log.warning('%s object with ID %s found in backend object '
-                        'store with ID %s'
-                        % (obj.__class__.__name__, obj.id, id))
+                    log.warning('%s object with ID %s found in backend object store with ID %s'
+                                % (obj.__class__.__name__, obj.id, id))
                     obj.object_store_id = id
                     _create_object_in_session( obj )
                     return id
@@ -702,14 +656,10 @@ class HierarchicalObjectStore(NestedObjectStore):
 
     def __init__(self, config, config_xml=None, fsmon=False):
         """The default contructor. Extends `NestedObjectStore`."""
-        super(HierarchicalObjectStore, self).__init__(
-            config, config_xml=config_xml)
+        super(HierarchicalObjectStore, self).__init__(config, config_xml=config_xml)
         self.backends = odict()
-        for b in sorted(config_xml.find('backends'),
-                key=lambda b: int(b.get('order'))):
-            self.backends[int(b.get('order'))] = \
-                build_object_store_from_config(
-                    config, fsmon=fsmon, config_xml=b)
+        for b in sorted(config_xml.find('backends'), key=lambda b: int(b.get('order'))):
+            self.backends[int(b.get('order'))] = build_object_store_from_config(config, fsmon=fsmon, config_xml=b)
 
     def exists(self, obj, **kwargs):
         """Check all child object stores."""
@@ -779,10 +729,9 @@ def local_extra_dirs( func ):
             for c in self.__class__.__mro__:
                 if c.__name__ == 'DiskObjectStore':
                     return getattr( c, func.__name__ )( self, *args, **kwargs )
-            raise Exception(
-                "Could not call DiskObjectStore's %s method, does your "
-                "Object Store plugin inherit from DiskObjectStore?"
-                % func.__name__ )
+            raise Exception("Could not call DiskObjectStore's %s method, does your "
+                            "Object Store plugin inherit from DiskObjectStore?"
+                            % func.__name__ )
     return wraps
 
 


### PR DESCRIPTION
We may want to revisit some of the longer function definitions, but this reverts them to how they were prior to the documentation overhaul (and matches with most of the rest of the codebase)
